### PR TITLE
Patch_fix_jsdoc_task_list

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "test": "jest",
-    "generate-docs": "node_modules/.bin/jsdoc --configure .jsdoc.json --verbose"
+    "generate-docs": "node_modules/.bin/jsdoc --configure .jsdoc.json --verbose --private"
   },
   "author": "ShellDivers",
   "devDependencies": {

--- a/source/components/task-list-component.js
+++ b/source/components/task-list-component.js
@@ -7,20 +7,17 @@
     /**
      * @type {ShadowRoot}
      * @private
-     * @property
      * @summary the shadow root of the task item Component
      */
     #shadow
     /**
      * @type {HTMLElement}
-     * @property
      * @private
      * @summary the Div that holds the task list
      */
     #task_list
     /**
      * @type {HTMLButtonElement}
-     * @property
      * @private
      * @summary the button to add a Task
      */


### PR DESCRIPTION
fixes #84 

removes properrty tag from task list and adds command line option to output private docs inside of the jsdoc output